### PR TITLE
7398 - Fixed resetFolionumberValidation return type to void

### DIFF
--- a/src/components/folio-number-input/FolioNumberInput.vue
+++ b/src/components/folio-number-input/FolioNumberInput.vue
@@ -74,7 +74,7 @@ export default class FolioNumberInput extends Vue {
   *  This can be used through $refs from a parent
   *  component to reset folio number validation
   */
-  public resetFolioNumberValidation (): boolean {
+  public resetFolioNumberValidation (): void {
     this.$refs.folioForm.resetValidation()
   }
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#7398

*Description of changes:*

- Fixed resetFolionumberValidation return type to void

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
