### PR TITLE
13399 Certify component not displaying red error bar and texts

### DIFF
--- a/src/components/certify/Certify.stories.ts
+++ b/src/components/certify/Certify.stories.ts
@@ -22,5 +22,6 @@ Default.args = {
   message: 'Note: It is an offence to make a false or misleading statement in respect of a material fact in a \n' +
     'record submitted to the Corporate Registry for filing. See section 427 of the Business Corporations Act.',
   entityDisplay: 'BC Company',
-  disableEdit: false
+  disableEdit: false,
+  invalidSection: false
 }

--- a/src/components/certify/Certify.vue
+++ b/src/components/certify/Certify.vue
@@ -192,6 +192,12 @@ export default class Certify extends Vue {
   line-height: 1.2rem;
   font-size: $px-16;
 
+  &.invalid-section {
+    border-left: 3px solid $app-red !important;
+    border-top-left-radius: 0 !important;
+    border-bottom-left-radius: 0 !important;
+  }
+
   .error-text {
     color: $app-red;
   }

--- a/src/components/certify/Certify.vue
+++ b/src/components/certify/Certify.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="AR-step-4-container">
+  <div id="AR-step-4-container" :class="{'invalid-section': invalidSection}">
     <v-form ref="certifyForm" lazy-validation v-on:submit.prevent>
       <v-row no-gutters>
         <v-col cols="12" :sm="firstColumn" class="pr-4 pb-4">
@@ -191,6 +191,10 @@ export default class Certify extends Vue {
 #AR-step-4-container {
   line-height: 1.2rem;
   font-size: $px-16;
+
+  .error-text {
+    color: $app-red;
+  }
 }
 
 .title-label {

--- a/tests/unit/Certify.spec.ts
+++ b/tests/unit/Certify.spec.ts
@@ -138,6 +138,7 @@ describe('Certify', () => {
     const wrapper: Wrapper<Certify> =
       createComponent(null, true, false, null, false, true)
 
+    expect(wrapper.find('.invalid-section').exists()).toBe(true)
     expect(wrapper.find('.error-text').exists()).toBe(true)
   })
 

--- a/tests/unit/date-mixin.spec.ts
+++ b/tests/unit/date-mixin.spec.ts
@@ -76,3 +76,4 @@ describe('Date Mixin', () => {
     expect(vm.apiToPacificDateTime('2021-01-01T00:00:00+00:00')).toBe('December 31, 2020 at 4:00 pm Pacific time') // PST
     expect(vm.apiToPacificDateTime('2021-07-01T00:00:00+00:00')).toBe('June 30, 2021 at 5:00 pm Pacific time') // PDT
   })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13399

*Description of changes:*
- fixed and enabled "invalid-section" for the certify component
- enforced css
- added unit test


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
