### PR TITLE
13875 NOB emits valid upon loading a save

### DIFF
--- a/src/components/nature-of-business/NatureOfBusiness.vue
+++ b/src/components/nature-of-business/NatureOfBusiness.vue
@@ -242,6 +242,7 @@ export default class NatureOfBusiness extends Vue {
   @Watch('haveNaics', { immediate: true })
   private onHaveNaicsChanged (val: boolean): void {
     this.state = val ? States.SUMMARY : States.INITIAL
+    this.emitValid(this.haveNaics)
   }
 
   /** Called when this form's validity has changed. */


### PR DESCRIPTION
*Issue #:* /bcgov/entity#13875

*Description of changes:*
- Upon resuming a save NOB emits valid on saved changes


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
