### PR TITLE
14974 Updated approval type for limited restoration extensions

### DIFF
--- a/src/components/approval-type/ApprovalType.stories.ts
+++ b/src/components/approval-type/ApprovalType.stories.ts
@@ -41,3 +41,10 @@ draftViaRegistrarWithDates.args = {
   noticeDate: '2023-02-02',
   applicationDate: '2023-01-15'
 }
+
+export const draftExtensionWithCourtOrder = Template.bind({})
+draftExtensionWithCourtOrder.args = {
+  courtOrderNumber: '99-1234567',
+  isExtension: true,
+  isCourtOrderOnly: true
+}

--- a/src/components/approval-type/ApprovalType.vue
+++ b/src/components/approval-type/ApprovalType.vue
@@ -6,11 +6,16 @@
       </v-col>
       <v-col cols="12" sm="9" class="mt-n4">
         <v-radio-group class="payment-group pt-0" v-model="approvalTypeSelected" @change="radioButtonChanged">
-          <!-- COURT ORDER radio button -->
-          <v-radio id="court-order-radio" class="mb-0"
-            :label="getRadioText(ApprovalTypes.VIA_COURT_ORDER)"
-            :value="ApprovalTypes.VIA_COURT_ORDER"
-          />
+          <!-- COURT ORDER section -->
+          <template v-if="isExtension">
+            <span class="v-label ml-8">{{ getRadioText(ApprovalTypes.VIA_COURT_ORDER) }}</span>
+          </template>
+          <template v-else>
+            <v-radio id="court-order-radio" class="mb-0"
+              :label="getRadioText(ApprovalTypes.VIA_COURT_ORDER)"
+              :value="ApprovalTypes.VIA_COURT_ORDER"
+            />
+          </template>
           <v-form ref="courtNumRef" id="court-num-form" v-model="valid" class="mt-4 ml-8">
             <v-expand-transition class="pb-0 mb-0">
               <v-text-field
@@ -25,7 +30,7 @@
               />
             </v-expand-transition>
           </v-form>
-          <!-- REGISTRAR radio button -->
+          <!-- REGISTRAR section -->
           <v-radio v-if="!isCourtOrderOnly"
             id="registrar-radio" class="mb-0 pt-2"
             :label="getRadioText(ApprovalTypes.VIA_REGISTRAR)"
@@ -108,6 +113,9 @@ export default class ApprovalType extends Vue {
   /** Whether this section is invalid. */
   @Prop({ default: false }) readonly invalidSection!: boolean
 
+  /** Whether the filing is limited restoration extension. */
+  @Prop({ default: false }) readonly isExtension!: boolean
+
   // Local properties
   private courtOrderNumberText = ''
   private valid = false
@@ -142,6 +150,9 @@ export default class ApprovalType extends Vue {
     } else {
       // Default state (no button selected)
       this.radioButtonChanged('')
+    }
+    if (this.isExtension) {
+      this.approvalTypeSelected = ApprovalTypes.VIA_COURT_ORDER
     }
   }
 
@@ -188,8 +199,10 @@ export default class ApprovalType extends Vue {
   }
 
   private getRadioText (option: string): string {
-    if (option === ApprovalTypes.VIA_COURT_ORDER) {
+    if (option === ApprovalTypes.VIA_COURT_ORDER && !this.isExtension) {
       return `This ${this.filingType} is approved by court order.`
+    } else if (option === ApprovalTypes.VIA_COURT_ORDER && this.isExtension) {
+      return 'Enter a Court Order number, as the restoration of this company was ordered by the court'
     }
     if (option === ApprovalTypes.VIA_REGISTRAR) {
       return `This ${this.filingType} is approved by registrar.`

--- a/tests/unit/ApprovalType.spec.ts
+++ b/tests/unit/ApprovalType.spec.ts
@@ -18,7 +18,8 @@ function createDefaultComponent (
   approvedByRegistrar: boolean = false,
   noticeDate: string = '',
   applicationDate: string = '',
-  filingType: string = 'restoration'
+  filingType: string = 'restoration',
+  isExtension: boolean = false
 ): Wrapper<ApprovalType> {
   return mount(ApprovalType, {
     propsData: {
@@ -26,7 +27,8 @@ function createDefaultComponent (
       approvedByRegistrar,
       noticeDate,
       applicationDate,
-      filingType
+      filingType,
+      isExtension
     },
     vuetify,
     localVue
@@ -154,6 +156,13 @@ describe('Initialize ApprovalType component', () => {
 
     expect(wrapper.emitted('update:noticeDate').pop()[0]).toEqual('2023-02-05')
     expect(wrapper.emitted('update:applicationDate').pop()[0]).toEqual('2023-01-19')
+    wrapper.destroy()
+  })
+
+  it('loads draft data correctly when court order selected when draft is extension', async () => {
+    const wrapper: Wrapper<ApprovalType> = createDefaultComponent('1234-567890', false, '', '', 'restoration', true)
+    expect(wrapper.vm.$data.courtOrderNumberText).toBe('1234-567890')
+    expect(wrapper.vm.$data.approvalTypeSelected).toEqual('courtOrder')
     wrapper.destroy()
   })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#14974

*Description of changes:*
- Updated the approval type for limited restoration extensions.
- Removed the radio button. 

- When creating a new limited restoration:
![approval type limited](https://user-images.githubusercontent.com/122301442/225468607-4e14afd4-89cf-455f-af09-7f023de7be8e.PNG)
- When creating a new limited restoration extension:
![approval type extension](https://user-images.githubusercontent.com/122301442/225468689-9ac69c8e-de60-441b-bff9-0aa737be44cd.PNG)

For reference, check UXPin:
https://preview.uxpin.com/306da47387722817e24fc77fd71476a1869a05fe#/pages/160258061/simulate/sitemap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
