### PR TITLE
Small fix style path of base address

### DIFF
--- a/src/components/base-address/BaseAddress.vue
+++ b/src/components/base-address/BaseAddress.vue
@@ -484,7 +484,7 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
 </script>
 
 <style lang="scss" scoped>
-@import "../../assets/styles/theme.scss";
+@import "@/assets/styles/theme.scss";
 
 // Address Block Layout
 .address-block {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#17118

*Description of changes:*
Fixing can't find stylesheet to import error for BaseAddress.vue
![can't find stylesheet to import](https://github.com/bcgov/bcrs-shared-components/assets/122301442/006d4605-9a21-43d9-94c4-642773fce55e)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
