### PR TITLE
15863 moved radio buttons in approval type component closer together …

### DIFF
--- a/src/components/approval-type/ApprovalType.vue
+++ b/src/components/approval-type/ApprovalType.vue
@@ -20,12 +20,12 @@
         >
           <!-- COURT ORDER section -->
           <template v-if="!isCourtOrderRadio">
-            <span class="v-label ml-2">{{ getRadioText(ApprovalTypes.VIA_COURT_ORDER) }}</span>
+            <span class="v-label ml-2 mb-2">{{ getRadioText(ApprovalTypes.VIA_COURT_ORDER) }}</span>
           </template>
           <template v-else>
             <v-radio
               id="court-order-radio"
-              class="mb-0"
+              class="mb-n3"
               :label="getRadioText(ApprovalTypes.VIA_COURT_ORDER)"
               :value="ApprovalTypes.VIA_COURT_ORDER"
             />

--- a/src/components/approval-type/package.json
+++ b/src/components/approval-type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcrs-shared-components/approval-type",
-  "version": "1.0.32",
+  "version": "1.0.31",
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/approval-type/package.json
+++ b/src/components/approval-type/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcrs-shared-components/approval-type",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
…vertically

*Issue #:* /bcgov/entity#15863

*Description of changes:*

- Shifted the radio buttons in Approval type vertically to be closer together. This will make the spacing more proportional to the new dividing line. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
