### PR TITLE
18513 Changed transition from "expand" to "slide-y"

### DIFF
--- a/src/components/expandable-help/ExpandableHelp.vue
+++ b/src/components/expandable-help/ExpandableHelp.vue
@@ -11,7 +11,7 @@
       <span class="pl-2 help-label">{{ !helpToggle ? helpLabel : 'Hide Help' }}</span>
     </div>
 
-    <v-expand-transition>
+    <v-slide-y-transition hide-on-leave>
       <div
         v-show="helpToggle"
         class="help-section mt-3 pa-6"
@@ -29,7 +29,7 @@
           </div>
         </div>
       </div>
-    </v-expand-transition>
+    </v-slide-y-transition>
   </div>
 </template>
 


### PR DESCRIPTION
*Issue #:* bcgov/entity#18513

*Description of changes:*
Since the expand transition was jerky, I changed it to "slide-y" along with the `hide-on-leave` options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).