### PR TITLE
18535 - Business Lookup specific legal types if passed as prop

### DIFF
--- a/src/components/business-lookup/BusinessLookup.vue
+++ b/src/components/business-lookup/BusinessLookup.vue
@@ -157,6 +157,9 @@ export default class BusinessLookup extends Vue {
   /** Label for BusinessLookup component. */
   @Prop({ default: 'Business or Corporation Name or Incorporation Number' }) readonly label!: string
 
+  /** BusinessLookup legal types to search for. */
+  @Prop({ default: 'BC,A,ULC,C,S,XP,GP,LP,CUL,XS,LLC,LL,BEN,CP,CC,XL,FI,XCP,PA' }) readonly legalTypes!: string
+
   // enum for template
   readonly States = States
 
@@ -221,7 +224,7 @@ export default class BusinessLookup extends Vue {
     if (searchInput?.length > 2) {
       that.state = States.SEARCHING
       that.searchResults =
-        await that.BusinessLookupServices.search(searchInput, that.searchStatus).catch(() => [])
+        await that.BusinessLookupServices.search(searchInput, that.searchStatus, that.legalTypes).catch(() => [])
       // display appropriate section
       that.state = (that.searchResults.length > 0) ? States.SHOW_RESULTS : States.NO_RESULTS
     } else {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18535

*Description of changes:*
- Added a prop to specify which legal types are we searching for.

The idea is to ultimately pass this in the BusinessLookup when doing an amalgamation:
`legalTypes="BC,BEN,CC,ULC,A"`

This is since, according to Mihai, those are the legalTypes we'll be searching for when doing an amalgamation.

I tried as much as possible to achieve this without actually changing the component here but I couldn't.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
