### PR TITLE
18777 - Vue3 upgrade: enums, interfaces, mixins PART 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@bcrs-shared-components/mixins": "^1.1.16",
         "@mdi/font": "^5.9.55",
+        "@vuelidate/core": "^2.0.3",
+        "@vuelidate/validators": "^2.0.4",
         "@vuepic/vue-datepicker": "^7.2.2",
         "axios": "^0.27.2",
         "country-list": "^2.3.0",
@@ -21,7 +23,6 @@
         "vue": "^3.3.4",
         "vue-router": "^3.6.5",
         "vue-the-mask": "^0.11.1",
-        "vuelidate": "^0.7.4",
         "vuetify": "^3.4.5"
       },
       "devDependencies": {
@@ -7240,6 +7241,90 @@
       "resolved": "https://registry.npmjs.org/vue-component-type-helpers/-/vue-component-type-helpers-1.6.5.tgz",
       "integrity": "sha512-iGdlqtajmiqed8ptURKPJ/Olz0/mwripVZszg6tygfZSIL9kYFPJTNY6+Q6OjWGznl2L06vxG5HvNvAnWrnzbg==",
       "dev": true
+    },
+    "node_modules/@vuelidate/core": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@vuelidate/core/-/core-2.0.3.tgz",
+      "integrity": "sha512-AN6l7KF7+mEfyWG0doT96z+47ljwPpZfi9/JrNMkOGLFv27XVZvKzRLXlmDPQjPl/wOB1GNnHuc54jlCLRNqGA==",
+      "dependencies": {
+        "vue-demi": "^0.13.11"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuelidate/core/node_modules/vue-demi": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuelidate/validators": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@vuelidate/validators/-/validators-2.0.4.tgz",
+      "integrity": "sha512-odTxtUZ2JpwwiQ10t0QWYJkkYrfd0SyFYhdHH44QQ1jDatlZgTh/KRzrWVmn/ib9Gq7H4hFD4e8ahoo5YlUlDw==",
+      "dependencies": {
+        "vue-demi": "^0.13.11"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vuelidate/validators/node_modules/vue-demi": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.13.11.tgz",
+      "integrity": "sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@vuepic/vue-datepicker": {
       "version": "7.2.2",
@@ -21230,15 +21315,6 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/vue-the-mask/-/vue-the-mask-0.11.1.tgz",
       "integrity": "sha512-UquSfnSWejD0zAfcD+3jJ1chUAkOAyoxya9Lxh9acCRtrlmGcAIvd0cQYraWqKenbuZJUdum+S174atv2AuEHQ=="
-    },
-    "node_modules/vuelidate": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.4.tgz",
-      "integrity": "sha512-QHZWYOL325Zo+2K7VBNEJTZ496Kd8Z31p85aQJFldKudUUGBmgw4zu4ghl4CyqPwjRCmqZ9lDdx4FSdMnu4fGg==",
-      "engines": {
-        "node": ">= 4.0.0",
-        "npm": ">= 3.0.0"
-      }
     },
     "node_modules/vuetify": {
       "version": "3.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "bcrs-shared-components",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "bcrs-shared-components",
-      "version": "3.0.3",
+      "version": "3.0.4",
       "dependencies": {
         "@bcrs-shared-components/mixins": "^1.1.16",
         "@mdi/font": "^5.9.55",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bcrs-shared-components",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "private": true,
   "appName": "BCRS Shared Components",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "vue": "^3.3.4",
     "vue-router": "^3.6.5",
     "vue-the-mask": "^0.11.1",
-    "vuelidate": "^0.7.4",
+    "@vuelidate/core": "^2.0.3",
+    "@vuelidate/validators": "^2.0.4",
     "vuetify": "^3.4.5"
   },
   "devDependencies": {

--- a/src/interfaces/package.json
+++ b/src/interfaces/package.json
@@ -6,6 +6,6 @@
   },
   "dependencies": {
     "@bcrs-shared-components/enums": "^1.0.51",
-    "vue": "^2.7.14"
+    "vue": "^3.3.4"
   }
 }

--- a/src/mixin-tester.vue
+++ b/src/mixin-tester.vue
@@ -4,11 +4,19 @@
 
 <script lang="ts">
 import { Component, mixins } from 'vue-facing-decorator'
-import { CountriesProvincesMixin, DateMixin, NameRequestMixin, ValidationMixin } from '@/mixins'
+import { CountriesProvincesMixin,
+  DateMixin,
+  NameRequestMixin,
+  ValidationMixin
+} from '@/mixins'
 
 @Component({})
-export default class MixinTester extends mixins(CountriesProvincesMixin, DateMixin, 
-  NameRequestMixin, ValidationMixin) {}
+export default class MixinTester extends mixins(
+  CountriesProvincesMixin,
+  DateMixin,
+  NameRequestMixin,
+  ValidationMixin
+) {}
 </script>
 
 <style>

--- a/src/mixin-tester.vue
+++ b/src/mixin-tester.vue
@@ -1,0 +1,15 @@
+<template>
+  <div class="d-none" />
+</template>
+
+<script lang="ts">
+import { Component, mixins } from 'vue-facing-decorator'
+import { CountriesProvincesMixin, DateMixin, NameRequestMixin, ValidationMixin } from '@/mixins'
+
+@Component({})
+export default class MixinTester extends mixins(CountriesProvincesMixin, DateMixin, 
+  NameRequestMixin, ValidationMixin) {}
+</script>
+
+<style>
+</style>

--- a/src/mixin-tester.vue
+++ b/src/mixin-tester.vue
@@ -3,20 +3,20 @@
 </template>
 
 <script lang="ts">
-import { Component, mixins } from 'vue-facing-decorator'
+import { Component, toNative, Vue } from 'vue-facing-decorator'
 import { CountriesProvincesMixin,
   DateMixin,
   NameRequestMixin,
   ValidationMixin
 } from '@/mixins'
 
-@Component({})
-export default class MixinTester extends mixins(
-  CountriesProvincesMixin,
-  DateMixin,
-  NameRequestMixin,
-  ValidationMixin
-) {}
+@Component({
+  mixins: [toNative(CountriesProvincesMixin),
+    toNative(DateMixin),
+    toNative(NameRequestMixin),
+    toNative(ValidationMixin)]
+})
+export default class MixinTester extends Vue {}
 </script>
 
 <style>

--- a/src/mixins/package.json
+++ b/src/mixins/package.json
@@ -10,9 +10,9 @@
     "country-list": "^2.3.0",
     "lodash": "4.17.21",
     "provinces": "^1.11.0",
-    "vue": "^2.7.14"
+    "vue": "^3.3.4"
   },
   "devDependencies": {
-    "vue-property-decorator": "^9.1.2"
+    "vue-facing-decorator": "^3.0.3"
   }
 }

--- a/src/mixins/validation-mixin.ts
+++ b/src/mixins/validation-mixin.ts
@@ -5,6 +5,7 @@ import { Component, Vue } from 'vue-facing-decorator'
  */
 @Component({})
 export default class ValidationMixin extends Vue {
+  $v: any
   /**
    * Creates a Vuetify rules object from the Vuelidate state.
    * @param model The name of the model we are validating.

--- a/src/mixins/validation-mixin.ts
+++ b/src/mixins/validation-mixin.ts
@@ -1,11 +1,12 @@
 import { Component, Vue } from 'vue-facing-decorator'
+import useVuelidate from '@vuelidate/core'
 
 /**
  * Mixin that provides some useful validation utilities.
  */
 @Component({})
 export default class ValidationMixin extends Vue {
-  $v: any
+  $v = useVuelidate()
   /**
    * Creates a Vuetify rules object from the Vuelidate state.
    * @param model The name of the model we are validating.

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -14,9 +14,9 @@ export default createVuetify({
     defaultSet: 'mdi',
     aliases,
     sets: {
-      mdi,
-    },
+      mdi
+    }
   },
   components,
-  directives,
+  directives
 })

--- a/src/services/package.json
+++ b/src/services/package.json
@@ -9,6 +9,6 @@
     "@bcrs-shared-components/interfaces": "^1.0.76",
     "axios": "^0.27.2",
     "lodash": "4.17.21",
-    "vue": "^2.7.14"
+    "vue": "^3.3.4"
   }
 }

--- a/tests/unit/common-util.spec.ts
+++ b/tests/unit/common-util.spec.ts
@@ -1,4 +1,4 @@
-import { getBoolean, decodeKCToken } from '../../src/utils/common-util'
+import { getBoolean, decodeKCToken, getAccountIdFromCurrentUrl } from '../../src/utils/common-util'
 
 const KEYCLOAK_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3F' +
   'QbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI0MmMzOWQzYi1iMTZkLTRiYWMtOWU1Ny1hNDYyZjQ3NWY0M2UiLCJleHAiO' +
@@ -15,7 +15,7 @@ const KEYCLOAK_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdt
   'OutPePeAmozIQhmf5jlZBW_J8qSzx9GmkQvT41hxpNLkaMPjPYVM2Iy6vL4Pnu0Xma-wCN1GCPwvJGQXCuh3IsR_iTMoig8qcFS0a0lUTx_cCj' +
   'G-zf_goG4vDTeKn6Mk50FToRtYGXkzWdfQn1T_yeS_2zrL8Ifg1QhJe74U_w40v4ikAFl-BofYnIRjopP57H-5g9_SGg'
 
-describe('Common Util Test', () => {
+describe('Common Util', () => {
   beforeAll(() => {
     sessionStorage.clear()
     sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN)
@@ -23,7 +23,7 @@ describe('Common Util Test', () => {
     sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
   })
 
-  it('Test getBoolean works', () => {
+  it('Returns correct values for getBoolean()', () => {
     expect(getBoolean(true)).toBe(true)
     expect(getBoolean('True')).toBe(true)
     expect(getBoolean('true')).toBe(true)
@@ -36,9 +36,30 @@ describe('Common Util Test', () => {
     expect(getBoolean('')).toBe(false)
   })
 
-  it('Test1', () => {
+  it('Returns parsed decodeKCToken()', () => {
     expectTypeOf(decodeKCToken()).toBeObject()
     expect(decodeKCToken()).toHaveProperty('username')
     expect(decodeKCToken()).toHaveProperty('jti')
+  })
+
+  it('Returns correct accountid getAccountIdFromCurrentUrl()', () => {
+    delete window.location
+    window.location = {
+      origin: 'http://localhost',
+      pathname: '/businesses/edit/BC1234567/correction',
+      search: '?accountid=2288'
+    } as any
+
+    expect(getAccountIdFromCurrentUrl()).toBe('2288')
+  })
+
+  it('Returns false when accountid parameter not passed in url getAccountIdFromCurrentUrl()', () => {
+    delete window.location
+    window.location = {
+      origin: 'http://localhost',
+      pathname: '/staff/dashboard/active'
+    } as any
+
+    expect(getAccountIdFromCurrentUrl()).toBe(false)
   })
 })

--- a/tests/unit/common-util.spec.ts
+++ b/tests/unit/common-util.spec.ts
@@ -1,0 +1,44 @@
+import { getBoolean, decodeKCToken } from '../../src/utils/common-util'
+
+const KEYCLOAK_TOKEN = 'eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICJUbWdtZUk0MnVsdUZ0N3F' +
+  'QbmUtcTEzdDUwa0JDbjF3bHF6dHN0UGdUM1dFIn0.eyJqdGkiOiI0MmMzOWQzYi1iMTZkLTRiYWMtOWU1Ny1hNDYyZjQ3NWY0M2UiLCJleHAiO' +
+  'jE1NzUwNzI4MTEsIm5iZiI6MCwiaWF0IjoxNTc1MDQ0MDExLCJpc3MiOiJodHRwczovL3Nzby1kZXYucGF0aGZpbmRlci5nb3YuYmMuY2EvYXV' +
+  '0aC9yZWFsbXMvZmNmMGtwcXIiLCJhdWQiOlsic2JjLWF1dGgtd2ViIiwiYWNjb3VudCJdLCJzdWIiOiI4ZTVkZDYzNS01OGRkLTQ5YzUtYmViM' +
+  'S00NmE1ZDVhMTYzNWMiLCJ0eXAiOiJCZWFyZXIiLCJhenAiOiJzYmMtYXV0aC13ZWIiLCJhdXRoX3RpbWUiOjAsInNlc3Npb25fc3RhdGUiOiI' +
+  '5OGQ3Y2Y2Zi0xYTQ1LTQzMzUtYWU0OC02YzBiNTdlMGYwNTAiLCJhY3IiOiIxIiwiYWxsb3dlZC1vcmlnaW5zIjpbImh0dHA6Ly8xOTIuMTY4L' +
+  'jAuMTM6ODA4MC8iLCIxOTIuMTY4LjAuMTMiLCIqIiwiaHR0cDovLzE5Mi4xNjguMC4xMzo4MDgwIl0sInJlYWxtX2FjY2VzcyI6eyJyb2xlcyI' +
+  '6WyJlZGl0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImJhc2ljIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsiYWNjb3Vud' +
+  'CI6eyJyb2xlcyI6WyJtYW5hZ2UtYWNjb3VudCIsIm1hbmFnZS1hY2NvdW50LWxpbmtzIiwidmlldy1wcm9maWxlIl19fSwic2NvcGUiOiIiLCJ' +
+  'yb2xlcyI6WyJlZGl0Iiwib2ZmbGluZV9hY2Nlc3MiLCJ1bWFfYXV0aG9yaXphdGlvbiIsImJhc2ljIl0sInByZWZlcnJlZF91c2VybmFtZSI6I' +
+  'mJjMDAwNzI5MSIsImxvZ2luU291cmNlIjoiUEFTU0NPREUiLCJ1c2VybmFtZSI6ImJjMDAwNzI5MSJ9.GYKmp5SQxZYTEkltSgaM3LMNcmuo_n' +
+  'b88wrYb6LbRk1BtCC0wU6Uu5zij_6mwXKyJ3dQ0L2EWR0eEqDuKzjWKVkIvQujXKzc8H9PPYPhgRqwdDr2qOglJrT2lJTkGZvPPqI217J2iiVW' +
+  'OutPePeAmozIQhmf5jlZBW_J8qSzx9GmkQvT41hxpNLkaMPjPYVM2Iy6vL4Pnu0Xma-wCN1GCPwvJGQXCuh3IsR_iTMoig8qcFS0a0lUTx_cCj' +
+  'G-zf_goG4vDTeKn6Mk50FToRtYGXkzWdfQn1T_yeS_2zrL8Ifg1QhJe74U_w40v4ikAFl-BofYnIRjopP57H-5g9_SGg'
+
+describe('Common Util Test', () => {
+  beforeAll(() => {
+    sessionStorage.clear()
+    sessionStorage.setItem('KEYCLOAK_TOKEN', KEYCLOAK_TOKEN)
+    sessionStorage.setItem('BUSINESS_ID', 'CP0001191')
+    sessionStorage.setItem('CURRENT_ACCOUNT', '{ "id": "2288" }')
+  })
+
+  it('Test getBoolean works', () => {
+    expect(getBoolean(true)).toBe(true)
+    expect(getBoolean('True')).toBe(true)
+    expect(getBoolean('true')).toBe(true)
+    expect(getBoolean('TRUE')).toBe(true)
+    expect(getBoolean(1)).toBe(true)
+    expect(getBoolean('1')).toBe(true)
+    expect(getBoolean('on')).toBe(true)
+    expect(getBoolean('yes')).toBe(true)
+    expect(getBoolean('False')).toBe(false)
+    expect(getBoolean('')).toBe(false)
+  })
+
+  it('Test1', () => {
+    expectTypeOf(decodeKCToken()).toBeObject()
+    expect(decodeKCToken()).toHaveProperty('username')
+    expect(decodeKCToken()).toHaveProperty('jti')
+  })
+})

--- a/tests/unit/countries-provinces-mixin.spec.ts
+++ b/tests/unit/countries-provinces-mixin.spec.ts
@@ -1,0 +1,59 @@
+import { shallowMount } from '@vue/test-utils'
+import MixinTester from '@/mixin-tester.vue'
+import { nextTick } from 'vue'
+
+const canadaProvinces = [
+  { name: 'Alberta', short: 'AB' },
+  { name: 'British Columbia', short: 'BC' },
+  { name: 'Manitoba', short: 'MB' },
+  { name: 'New Brunswick', short: 'NB' },
+  { name: 'Newfoundland and Labrador', short: 'NL' },
+  { name: 'Northwest Territories', short: 'NT' },
+  { name: 'Nova Scotia', short: 'NS' },
+  { name: 'Nunavut', short: 'NU' },
+  { name: 'Ontario', short: 'ON' },
+  { name: 'Prince Edward Island', short: 'PE' },
+  { name: 'Quebec', short: 'QC' },
+  { name: 'Saskatchewan', short: 'SK' },
+  { name: 'Yukon', short: 'YT' }
+]
+
+const canadaProvincesExcludeBC = [
+  { name: 'Alberta', short: 'AB' },
+  { name: 'Manitoba', short: 'MB' },
+  { name: 'New Brunswick', short: 'NB' },
+  { name: 'Newfoundland and Labrador', short: 'NL' },
+  { name: 'Northwest Territories', short: 'NT' },
+  { name: 'Nova Scotia', short: 'NS' },
+  { name: 'Nunavut', short: 'NU' },
+  { name: 'Ontario', short: 'ON' },
+  { name: 'Prince Edward Island', short: 'PE' },
+  { name: 'Quebec', short: 'QC' },
+  { name: 'Saskatchewan', short: 'SK' },
+  { name: 'Yukon', short: 'YT' }
+]
+
+describe('Countries Provinces Mixin', () => {
+  let vm: any
+
+  beforeAll(async () => {
+    // mount the component and wait for everything to stabilize
+    const wrapper = shallowMount(MixinTester)
+    vm = wrapper.vm
+    await nextTick()
+  })
+
+  it('returns correct country name getCountryName()', () => {
+    expect(vm.getCountryName('CA')).toBe('Canada')
+  })
+
+  it('returns correct country name getCountryRegions()', () => {
+    expect(vm.getCountryRegions('CA')).length(13)
+    expect(vm.getCountryRegions('CA')).toMatchObject(canadaProvinces)
+  })
+
+  it('returns correct country name getCanadaRegionsExcludeBC()', () => {
+    expect(vm.getCanadaRegionsExcludeBC('CA')).length(12)
+    expect(vm.getCanadaRegionsExcludeBC('CA')).toMatchObject(canadaProvincesExcludeBC)
+  })
+})

--- a/tests/unit/countries-provinces-mixin.spec.ts
+++ b/tests/unit/countries-provinces-mixin.spec.ts
@@ -18,21 +18,6 @@ const canadaProvinces = [
   { name: 'Yukon', short: 'YT' }
 ]
 
-const canadaProvincesExcludeBC = [
-  { name: 'Alberta', short: 'AB' },
-  { name: 'Manitoba', short: 'MB' },
-  { name: 'New Brunswick', short: 'NB' },
-  { name: 'Newfoundland and Labrador', short: 'NL' },
-  { name: 'Northwest Territories', short: 'NT' },
-  { name: 'Nova Scotia', short: 'NS' },
-  { name: 'Nunavut', short: 'NU' },
-  { name: 'Ontario', short: 'ON' },
-  { name: 'Prince Edward Island', short: 'PE' },
-  { name: 'Quebec', short: 'QC' },
-  { name: 'Saskatchewan', short: 'SK' },
-  { name: 'Yukon', short: 'YT' }
-]
-
 describe('Countries Provinces Mixin', () => {
   let vm: any
 
@@ -53,7 +38,8 @@ describe('Countries Provinces Mixin', () => {
   })
 
   it('returns correct country name getCanadaRegionsExcludeBC()', () => {
+    const testExcludeBc = canadaProvinces.filter(p => p.short !== 'BC')
     expect(vm.getCanadaRegionsExcludeBC('CA')).length(12)
-    expect(vm.getCanadaRegionsExcludeBC('CA')).toMatchObject(canadaProvincesExcludeBC)
+    expect(vm.getCanadaRegionsExcludeBC('CA')).toMatchObject(testExcludeBc)
   })
 })

--- a/tests/unit/date-mixin.spec.ts
+++ b/tests/unit/date-mixin.spec.ts
@@ -1,21 +1,15 @@
-/* eslint max-len: 0 */
-import Vue from 'vue'
-import Vuetify from 'vuetify'
 import { shallowMount } from '@vue/test-utils'
-import DatePicker from '@/components/date-picker/DatePicker.vue'
-import DateMixin from '@/mixins/date-mixin'
-
-const vuetify = new Vuetify({})
+import MixinTester from '@/mixin-tester.vue'
+import { nextTick } from 'vue'
 
 describe('Date Mixin', () => {
   let vm: any
 
   beforeAll(async () => {
     // mount the component and wait for everything to stabilize
-    // (this can be any component since we are not really using it)
-    const wrapper = shallowMount(DatePicker, { vuetify, mixins: [DateMixin] })
+    const wrapper = shallowMount(MixinTester)
     vm = wrapper.vm
-    await Vue.nextTick()
+    await nextTick()
   })
 
   it('returns correct values for createUtcDate()', () => {
@@ -71,7 +65,8 @@ describe('Date Mixin', () => {
   })
 
   it('returns correct values for apiToPacificDateTime()', () => {
-    expect(vm.apiToPacificDateTime('2021-01-01T00:00:00+00:00')).toBe('December 31, 2020 at 4:00 pm Pacific time') // PST
+    expect(vm.apiToPacificDateTime('2021-01-01T00:00:00+00:00'))
+      .toBe('December 31, 2020 at 4:00 pm Pacific time') // PST
     expect(vm.apiToPacificDateTime('2021-07-01T00:00:00+00:00')).toBe('June 30, 2021 at 5:00 pm Pacific time') // PDT
   })
 

--- a/tests/unit/name-request-mixin.spec.ts
+++ b/tests/unit/name-request-mixin.spec.ts
@@ -1,0 +1,98 @@
+import { mount, shallowMount } from '@vue/test-utils'
+import MixinTester from '@/mixin-tester.vue'
+import { nextTick } from 'vue'
+
+const validNamerequest = {
+  nrNum: 'NR 1234567',
+  corpNum: 'BC1234567',
+  legalType: 'CP',
+  applicants: {
+    // address info
+    addrLine1: '1012 Douglas St',
+    addrLine2: 'Suite 200',
+    addrLine3: 'Second Floor',
+    city: 'Victoria',
+    stateProvinceCd: 'BC',
+    postalCd: 'V8W 2C3',
+    countryTypeCd: 'CA',
+    // contact info
+    emailAddress: 'email@example.com',
+    phoneNumber: '1234567890',
+    // name info
+    firstName: 'First',
+    middleName: 'Middle',
+    lastName: 'Last'
+  },
+  names: [
+    {
+      state: 'APPROVED',
+      name: 'Approved CP Namerequest'
+    }
+  ],
+  consentFlag: null,
+  expirationDate: '2022-07-05T06:59:00+00:00',
+  requestTypeCd: 'BEC',
+  request_action_cd: 'NEW',
+  state: 'APPROVED'
+}
+
+describe('Namerequest Mixin', () => {
+  let vm: any
+
+  beforeAll(async () => {
+    // mount the component and wait for everything to stabilize
+    const wrapper = mount(MixinTester)
+    vm = wrapper.vm
+    await nextTick()
+  })
+
+  it('identifies invalid NameRequest validateNameRequest()', () => {
+    let nr = null
+    expect(() => vm.validateNameRequest(nr)).toThrowError('Invalid Name Request: Invalid NR object')
+
+    nr = {}
+    expect(() => vm.validateNameRequest(nr)).toThrowError('Invalid Name Request: Invalid NR applicants')
+    expect(() => vm.validateNameRequest(validNamerequest, 'AML')).toThrowError('Incorrect Request Action Code')
+    expect(() => vm.validateNameRequest(validNamerequest, 'NEW', 'BC123456'))
+      .toThrowError('Incorrect Business ID')
+    expect(() => vm.validateNameRequest(validNamerequest, 'NEW', 'BC1234567', '1234567891'))
+      .toThrowError('Incorrect Phone Number')
+    expect(() => vm.validateNameRequest(validNamerequest, 'NEW', 'BC1234567', '1234567890', 'email1@example.com'))
+      .toThrowError('Incorrect Email Address')
+  })
+
+  it('returns valid NameRequest validateNameRequest()', () => {
+    expect(vm.isNrInvalid(validNamerequest, 'NEW', 'BC1234567', '1234567890', 'email1@example.com')).toBe(null)
+  })
+
+  it('returns invalid NameRequest isNrInvalid()', () => {
+    let nr = null
+    expect(vm.isNrInvalid(nr)).toBe('Invalid NR object')
+
+    nr = {}
+    expect(vm.isNrInvalid(nr)).toBe('Invalid NR applicants')
+  })
+
+  it('returns correct Name Request name getNrApprovedName()', () => {
+    expect(vm.getNrApprovedName({ names: [{ state: 'APPROVED', name: 'Approved CP Namerequest' }] }))
+      .toBe('Approved CP Namerequest')
+    expect(vm.getNrApprovedName({ names: [{ state: 'INPROGRESS', name: 'CP Namerequest' }] })).toBeUndefined()
+  })
+
+  it('returns correct Name Request state getNrState()', () => {
+    expect(vm.getNrState({ state: 'CONDITIONAL', consentFlag: 'Y' })).toBe('NEED_CONSENT')
+    expect(vm.getNrState({ state: 'DRAFT' })).toBe('NOT_APPROVED')
+    expect(vm.getNrState({ state: 'APPROVED' })).toBe('APPROVED')
+    expect(vm.getNrState({ state: 'CONDITIONAL', consentFlag: 'R' })).toBe('CONDITIONAL')
+    expect(vm.getNrState({ state: 'CONDITIONAL', consentFlag: 'N' })).toBe('CONDITIONAL')
+    expect(vm.getNrState({ state: 'CONSUMED' })).toBe('CONSUMED')
+    expect(vm.getNrState({ state: 'EXPIRED' })).toBe('EXPIRED')
+  })
+
+  it('returns correct NR request code description getNrRequestDesc(', () => {
+    expect(vm.getNrRequestDesc('NEW')).toBe('New Business')
+    expect(vm.getNrRequestDesc('CHG')).toBe('Change of Name')
+    expect(vm.getNrRequestDesc('CNV')).toBe('Conversion')
+    expect(vm.getNrRequestDesc('REH')).toBe('Restoration')
+  })
+})

--- a/tests/unit/validation-mixin.spec.ts
+++ b/tests/unit/validation-mixin.spec.ts
@@ -1,0 +1,25 @@
+import { shallowMount } from '@vue/test-utils'
+import MixinTester from '@/mixin-tester.vue'
+import { nextTick } from 'vue'
+
+describe('Validation Mixin', () => {
+  let vm: any
+
+  beforeAll(async () => {
+    // mount the component and wait for everything to stabilize
+    const wrapper = shallowMount(MixinTester)
+    vm = wrapper.vm
+    await nextTick()
+  })
+
+  it('returns correct Vuetify Rules object createVuetifyRulesObject()', () => {
+    expectTypeOf(vm.createVuetifyRulesObject('addressLocal')).toBeObject()
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('streetAddress')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('streetAddressAdditional')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('addressCity')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('addressRegion')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('postalCode')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('addressCountry')
+    expect(vm.createVuetifyRulesObject('addressLocal')).toHaveProperty('deliveryInstructions')
+  })
+})


### PR DESCRIPTION
*Issue #:* /bcgov/entity#18777

*Description of changes:*

**This is first PR. More coming your way....**

Update below to use Vue3/Vuetify3:
- enums: Looks okay and may not need any update
- interfaces: updated vue version to 3
- mixins: updated vue version to 3, added unit tests
- modules/corp-type-module: Looks okay and may not need any update
- services
- types: Looks okay and may not need any update
- utils (even though not exported): Looks okay and may not need any update, added unit test for `common-util`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
