### PR TITLE
Small fix to continuation in filing name

### DIFF
--- a/src/enums/filing-names.ts
+++ b/src/enums/filing-names.ts
@@ -11,7 +11,7 @@ export enum FilingNames {
   CHANGE_OF_NAME = 'Legal Name Change',
   CHANGE_OF_REGISTRATION = 'Change of Registration',
   CONVERSION = 'Record Conversion',
-  CONTINUATION_IN = 'Continuation In',
+  CONTINUATION_IN_APPLICATION = 'Continuation In Application',
   CONSENT_CONTINUATION_OUT = 'Consent to Continuation Out',
   CONTINUATION_OUT = 'Continuation Out',
   CORRECTION = 'Correction',


### PR DESCRIPTION
*Issue #:* /bcgov/entity#19258

*Description of changes:*
![continuation in application](https://github.com/bcgov/bcrs-shared-components/assets/122301442/43ec53cc-e0a2-461b-8e4a-2d67b11a21ca)

I need the title to be Continuation In Application (as per the UXPin). I missed that in my previous PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
