### PR TITLE
20989-add initial value prop

### DIFF
--- a/src/components/jurisdiction/Jurisdiction.stories.ts
+++ b/src/components/jurisdiction/Jurisdiction.stories.ts
@@ -16,3 +16,14 @@ export const Default = Template.bind({})
 Default['args'] = {
   showUsaJurisdictions: false
 }
+
+export const JurisdictionInitialValue = Template.bind({})
+JurisdictionInitialValue['args'] = {
+  showUsaJurisdictions: false,
+  initialValue: {
+    group: 0,
+    text: 'Alberta',
+    value: 'AB',
+    separator: false
+  }
+}

--- a/src/components/jurisdiction/Jurisdiction.stories.ts
+++ b/src/components/jurisdiction/Jurisdiction.stories.ts
@@ -21,9 +21,7 @@ export const JurisdictionInitialValue = Template.bind({})
 JurisdictionInitialValue['args'] = {
   showUsaJurisdictions: false,
   initialValue: {
-    group: 0,
-    text: 'Alberta',
-    value: 'AB',
-    separator: false
+    country: 'CA',
+    region: 'FD'
   }
 }

--- a/src/components/jurisdiction/Jurisdiction.vue
+++ b/src/components/jurisdiction/Jurisdiction.vue
@@ -10,20 +10,22 @@
 </template>
 
 <script lang="ts">
-import { Component, Emit, Prop, Vue } from 'vue-property-decorator'
+import { Component, Emit, Mixins, Prop } from 'vue-property-decorator'
 import NestedSelect from './NestedSelect.vue'
 import { JurisdictionLocation } from '@bcrs-shared-components/enums'
+import { ForeignJurisdictionIF } from '@bcrs-shared-components/interfaces'
+import { CountriesProvincesMixin } from '@bcrs-shared-components/mixins'
 import { CanJurisdictions, IntlJurisdictions, UsaJurisdiction } from './list-data'
 
 @Component({
   components: { NestedSelect }
 })
-export default class Jurisdiction extends Vue {
+export default class Jurisdiction extends Mixins(CountriesProvincesMixin) {
   // props
   @Prop({ default: 'Select the home jurisdiction' }) readonly label!: string
   @Prop() readonly errorMessages!: string
   @Prop({ default: false }) readonly showUsaJurisdictions!: boolean
-  @Prop({ default: null }) readonly initialValue!: string
+  @Prop({ default: null }) readonly initialValue!: ForeignJurisdictionIF[]
 
   // variables
   jurisdiction = null
@@ -31,7 +33,43 @@ export default class Jurisdiction extends Vue {
   /** Called when component is created. */
   created (): void {
     if (this.initialValue) {
-      this.jurisdiction = this.initialValue
+      this.setInitialValue()
+    }
+  }
+
+  /** Set initial value of jurisdiction */
+  setInitialValue (): void {
+    let jurisdictionGroup
+    let jurisdictionValue = ''
+    let jurisdictionText = ''
+
+    const initialJurValue = this.initialValue as ForeignJurisdictionIF
+    const country = initialJurValue.country
+    const region = initialJurValue.region ? initialJurValue.region : ''
+
+    if (country === JurisdictionLocation.CA) {
+      jurisdictionGroup = 0
+    } else if (country === JurisdictionLocation.US) {
+      jurisdictionGroup = 1
+    } else {
+      jurisdictionGroup = 2
+    }
+
+    if (region) {
+      if (region === JurisdictionLocation.FD) {
+        jurisdictionText = 'Federal'
+      } else {
+        let regions = this.getCountryRegions(country) as any[]
+        jurisdictionText = regions.find(p => p.short === region).name
+      }
+    } else {
+      jurisdictionText = this.getCountryName(country)
+    }
+
+    this.jurisdiction = {
+      group: jurisdictionGroup,
+      text: jurisdictionText,
+      value: jurisdictionValue
     }
   }
 

--- a/src/components/jurisdiction/Jurisdiction.vue
+++ b/src/components/jurisdiction/Jurisdiction.vue
@@ -23,9 +23,17 @@ export default class Jurisdiction extends Vue {
   @Prop({ default: 'Select the home jurisdiction' }) readonly label!: string
   @Prop() readonly errorMessages!: string
   @Prop({ default: false }) readonly showUsaJurisdictions!: boolean
+  @Prop({ default: null }) readonly initialValue!: string
 
   // variables
   jurisdiction = null
+
+  /** Called when component is created. */
+  created (): void {
+    if (this.initialValue) {
+      this.jurisdiction = this.initialValue
+    }
+  }
 
   /** The jursidiction select options */
   get jurisdictionOptions (): Array<any> {

--- a/src/interfaces/foreign-jurisdiction-interface.ts
+++ b/src/interfaces/foreign-jurisdiction-interface.ts
@@ -1,0 +1,8 @@
+/**
+ * See:
+ * https://github.com/bcgov/business-schemas/blob/main/src/registry_schemas/schemas/foreign_jurisdiction.json
+ */
+export interface ForeignJurisdictionIF {
+  country: string
+  region?: string
+}


### PR DESCRIPTION
*Issue #:* /bcgov/entity#20989

*Description of changes:*

Add initial value prop to retrieve value for a draft filing.

some initial value tests:

![image](https://github.com/bcgov/bcrs-shared-components/assets/116035339/119f3573-9ca2-447d-bedf-699056ee3181)

![image](https://github.com/bcgov/bcrs-shared-components/assets/116035339/af5eed6a-f973-4ca6-87b0-8852f0f853f1)

![image](https://github.com/bcgov/bcrs-shared-components/assets/116035339/5a6a078e-8f92-4fb2-b50a-27d0a8c76241)

![image](https://github.com/bcgov/bcrs-shared-components/assets/116035339/cf12ea01-7d73-402c-8604-442478e8a6de)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
