### PR TITLE
24918 - Change the country selector to the top

### DIFF
--- a/src/components/base-address/BaseAddress.vue
+++ b/src/components/base-address/BaseAddress.vue
@@ -20,6 +20,10 @@
         class="address-block"
       >
         <div class="address-block__info pre-line">
+          <div class="address-block__info-row address-country">
+            {{ getCountryName(addressCountry) }}
+          </div>
+
           <div class="address-block__info-row street-address">
             {{ addressLocal.streetAddress }}
           </div>
@@ -40,10 +44,6 @@
             </template>
           </div>
 
-          <div class="address-block__info-row address-country">
-            {{ getCountryName(addressCountry) }}
-          </div>
-
           <template v-if="addressLocal.deliveryInstructions">
             <div class="address-block__info-row delivery-instructions mt-5 font-italic">
               {{ addressLocal.deliveryInstructions }}
@@ -61,6 +61,26 @@
         name="address-form"
         lazy-validation
       >
+        <div class="form__row">
+          <v-select
+            v-model="addressLocal.addressCountry"
+            filled
+            class="address-country"
+            :label="addressCountryLabel"
+            menu-props="auto"
+            item-text="name"
+            item-value="code"
+            :items="getCountries()"
+            :rules="[...rules.addressCountry, ...spaceRules]"
+            @change="resetRegion()"
+          />
+          <!-- special field to select AddressComplete country, separate from our model field -->
+          <input
+            :id="addressCountryId"
+            type="hidden"
+            :value="addressCountry"
+          >
+        </div>
         <div class="form__row">
           <!-- NB1: AddressComplete needs to be enabled each time user clicks in this search field.
                NB2: Only process first keypress -- assumes if user moves between instances of this
@@ -127,26 +147,6 @@
             :label="postalCodeLabel"
             :rules="[...rules.postalCode, ...spaceRules]"
           />
-        </div>
-        <div class="form__row">
-          <v-select
-            v-model="addressLocal.addressCountry"
-            filled
-            class="address-country"
-            :label="addressCountryLabel"
-            menu-props="auto"
-            item-text="name"
-            item-value="code"
-            :items="getCountries()"
-            :rules="[...rules.addressCountry, ...spaceRules]"
-            @change="resetRegion()"
-          />
-          <!-- special field to select AddressComplete country, separate from our model field -->
-          <input
-            :id="addressCountryId"
-            type="hidden"
-            :value="addressCountry"
-          >
         </div>
         <div class="form__row">
           <v-textarea


### PR DESCRIPTION
*Issue #:* https://github.com/bcgov/entity/issues/24918

*Description of changes:*
change the country selector to the top so the input fields won’t be clearing info when a country is selected.
https://www.figma.com/design/0vRutcPRtoUIkPTQtG257r/Account-Update---Payment-Methods-and-Account-Type?node-id=5133-3475&t=dSNKFzhiftxhJ4m3-0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
