### PR TITLE
26560 - Prioritize Canada and US in the BaseAddress Country Selector

### DIFF
--- a/src/components/base-address/BaseAddress.vue
+++ b/src/components/base-address/BaseAddress.vue
@@ -70,7 +70,7 @@
             menu-props="auto"
             item-text="name"
             item-value="code"
-            :items="formatCountries()"
+            :items="getCountryList()"
             :rules="[...rules.addressCountry, ...spaceRules]"
             @change="resetRegion()"
           />
@@ -497,7 +497,7 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
     Vue.nextTick(() => { (this.$refs.addressForm as any).validate() })
   }
 
-  formatCountries (): Array<object> {
+  getCountryList (): Array<object> {
     const countries = this.getCountries()
 
     // List of priority countries

--- a/src/components/base-address/BaseAddress.vue
+++ b/src/components/base-address/BaseAddress.vue
@@ -70,7 +70,7 @@
             menu-props="auto"
             item-text="name"
             item-value="code"
-            :items="getCountries()"
+            :items="formatCountries()"
             :rules="[...rules.addressCountry, ...spaceRules]"
             @change="resetRegion()"
           />
@@ -495,6 +495,27 @@ export default class BaseAddress extends Mixins(ValidationMixin, CountriesProvin
 
     // Validate the form, in case any fields are missing or incorrect.
     Vue.nextTick(() => { (this.$refs.addressForm as any).validate() })
+  }
+
+  formatCountries (): Array<object> {
+    const countries = this.getCountries()
+
+    // List of priority countries
+    const priorityCountries = ['Canada', 'United States of America']
+
+    const prioritized = countries.filter((country: any) =>
+      priorityCountries.includes(country.name)
+    )
+
+    const list = countries.filter((country: any) =>
+      !priorityCountries.includes(country.name)
+    )
+
+    return [
+      ...prioritized,
+      { divider: true },
+      ...list
+    ]
   }
 
   combineLines (line1: string, line2: string) {


### PR DESCRIPTION
*Issue #:* /bcgov/entity#26560 

*Description of changes:*
- Move Canada and US to the top of the country list
- Add a divider line between Canada & US from the rest of the countries

![image](https://github.com/user-attachments/assets/fc54980f-964b-467f-a6c7-3fae62ad072c)

Changes mocked in Filings-UI:
![image](https://github.com/user-attachments/assets/84822783-b823-4183-afa3-3cab743b0a50)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
