### PR TITLE
Remove api key from session storage

### DIFF
--- a/src/services/utils/axios-instance.ts
+++ b/src/services/utils/axios-instance.ts
@@ -6,7 +6,7 @@ const instance = axios.create()
 
 instance.interceptors.request.use(
   request => {
-    request.headers['x-apikey'] = ConfigHelper.getFromSession('DOC_API_KEY')
+    request.headers['x-apikey'] = import.meta.env.VUE_APP_DOC_API_KEY
     request.headers['Account-Id'] = JSON.parse(ConfigHelper.getFromSession(SessionStorageKeys.CurrentAccount) || '{}')?.id || 0
 
     return request


### PR DESCRIPTION
*Issue #:* /bcgov/entity#29440

*Description of changes:*
Since the API key was removed from session storage, it now needs to be retrieved from `import.meta`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
