### PR TITLE
30411 - update to correct name component

### DIFF
--- a/src/components/correct-name/CorrectName.vue
+++ b/src/components/correct-name/CorrectName.vue
@@ -176,7 +176,7 @@ export default class CorrectName extends Vue {
     {
       id: CorrectNameOptions.CORRECT_NEW_NR_STAFF,
       title: 'Use a new name request number',
-      description: 'Enter the new Name Request Number (e.g., NR 1234567).',
+      description: null,
       component: CorrectNameRequestStaff
     }
   ]

--- a/src/components/correct-name/CorrectNameRequestStaff.vue
+++ b/src/components/correct-name/CorrectNameRequestStaff.vue
@@ -6,17 +6,6 @@
     lazy-validation
   >
     <v-row no-gutters>
-      <v-col
-        cols="1"
-        class="mt-3"
-      >
-        <v-chip
-          outlined
-          class="step-icon"
-        >
-          1
-        </v-chip>
-      </v-col>
       <v-col>
         <v-text-field
           id="nr-number"


### PR DESCRIPTION
*Issue #:* /bcgov/entity#30411

*Description of changes:*

Update based on review from Jacqueline (see her comment on ticket [30412](https://app.zenhub.com/workspaces/entities---olga-65af15f59e89f5043c2911f7/issues/gh/bcgov/entity/30412))

- remove the Number 1 next to the NR input field
- remove the text above "Enter the new Name Request Number (e.g., NR 1234567)" because it is redundant with the bolded text above it now that we have taken out the other part of the sentence regarding email and phone number.

**In Storybook after the fix:**

<img width="1835" height="547" alt="image" src="https://github.com/user-attachments/assets/206bdf95-3289-4fb8-84dd-4db4395c52d0" />

**Will look like this once import updated shared components in Create UI:**

<img width="1063" height="557" alt="image" src="https://github.com/user-attachments/assets/74be70d1-90be-40fb-92bc-a6d824a9a68d" />



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
