### PR TITLE
31830 - Validate Optional Phone Number in ContactInfo if Provided

### DIFF
--- a/src/components/contact-info/ContactInfo.vue
+++ b/src/components/contact-info/ContactInfo.vue
@@ -422,11 +422,11 @@ export default class ContactInfo extends Vue {
     ]
     this.phoneRules = this.optionalPhone
       ? [
-        (v: any) => !v || (v.length === 0 || v.length === 14) || 'Phone number is invalid'
+        (v: any) => !v || (v.length === 0 || v.length === 14) || 'Enter a valid phone number'
       ]
       : [
         (v: string) => !!v || 'Phone number is required',
-        (v: any) => !v || (v.length === 0 || v.length === 14) || 'Phone number is invalid'
+        (v: any) => !v || (v.length === 0 || v.length === 14) || 'Enter a valid phone number'
       ]
 
     // Validate form and wait for v-model to get updated

--- a/src/components/contact-info/ContactInfo.vue
+++ b/src/components/contact-info/ContactInfo.vue
@@ -420,7 +420,10 @@ export default class ContactInfo extends Vue {
       (v: string) => !v || (v.toString() === (this.$refs.editContactForm && this.$refs.editContactForm.$el[0].value)) ||
         'Email addresses must match'
     ]
-    this.phoneRules = this.optionalPhone ? []
+    this.phoneRules = this.optionalPhone
+      ? [
+        (v: any) => !v || (v.length === 0 || v.length === 14) || 'Phone number is invalid'
+      ]
       : [
         (v: string) => !!v || 'Phone number is required',
         (v: any) => !v || (v.length === 0 || v.length === 14) || 'Phone number is invalid'

--- a/tests/unit/ContactInfo.spec.ts
+++ b/tests/unit/ContactInfo.spec.ts
@@ -183,4 +183,46 @@ describe('Business Contact Info component', () => {
 
     wrapper.destroy()
   })
+
+  it('Allows optional phone to be empty', async () => {
+    const wrapper: Wrapper<ContactInfo> =
+      createComponent(originalBusinessContactInfo, originalBusinessContactInfo)
+
+    // Set optional prop
+    wrapper.setProps({ optionalPhone: true })
+    await Vue.nextTick()
+
+    wrapper.find(editButtonSelector).trigger('click')
+    await Vue.nextTick()
+    await (wrapper.vm as any).submitContact()
+    await Vue.nextTick()
+
+    const rules = (wrapper.vm as any).phoneRules
+    const result = rules[0]('')
+
+    expect(result).toBe(true)
+    wrapper.destroy()
+  })
+
+  it('Validates optional phone format if provided', async () => {
+    const wrapper: Wrapper<ContactInfo> =
+      createComponent(originalBusinessContactInfo, originalBusinessContactInfo)
+
+    // Set optional prop
+    wrapper.setProps({ optionalPhone: true })
+    await Vue.nextTick()
+
+    wrapper.find(editButtonSelector).trigger('click')
+    await Vue.nextTick()
+    await (wrapper.vm as any).submitContact()
+    await Vue.nextTick()
+
+    const rules = (wrapper.vm as any).phoneRules
+    let result = rules[0]('(555) 555-5555')
+    expect(result).toBe(true)
+
+    result = rules[0]('5555555555')
+    expect(result).toBe('Enter a valid phone number')
+    wrapper.destroy()
+  })
 })


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31830 

*Description of changes:*
- Validate the format of the optional phone number **if** provided, still allows this field to be left blank (this aligns with the behaviour in [create-ui](https://github.com/bcgov/business-create-ui/blob/main/src/rules/phone-rules.ts#L4) for the optional phone number)
- Discussed and approved by Jacqueline


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
