### PR TITLE
31843 - Add authorizationMode prop to Certify component

### DIFF
--- a/src/components/certify/Certify.stories.ts
+++ b/src/components/certify/Certify.stories.ts
@@ -22,5 +22,6 @@ Default['args'] = {
     'record submitted to the Corporate Registry for filing. See section 427 of the Business Corporations Act.',
   entityDisplay: 'BC Company',
   disableEdit: false,
-  showLegalName: true
+  showLegalName: true,
+  authorizationMode: 'certify'
 }

--- a/src/components/certify/Certify.vue
+++ b/src/components/certify/Certify.vue
@@ -45,7 +45,9 @@
             v-if="!showLegalName"
             class="title-label"
             :class="{'error-text': invalidSection}"
-          >Confirm Authorization</label>
+          >
+            {{ authorizationTitle }}
+          </label>
         </v-col>
         <v-col
           cols="12"
@@ -63,8 +65,7 @@
                 class="certify-stmt"
                 :class="{'error-text': invalidSection && !isCertified}"
               >
-                I confirm that the information provided is correct and that I am authorized to
-                submit this filing on behalf of the {{ entityDisplay || "[entity type]" }}.
+                {{ checkboxLabelText }}
               </div>
               <div
                 v-else-if="isStaff"
@@ -188,6 +189,9 @@ export default class Certify extends Vue {
   /** Show Legal Name prop. */
   @Prop({ default: true }) readonly showLegalName!: boolean
 
+  /** Authorization Mode prop. */
+  @Prop({ default: 'certify' }) readonly authorizationMode!: 'confirm' | 'certify'
+
   // Form Ref
   $refs: { certifyForm: FormIF }
 
@@ -208,6 +212,18 @@ export default class Certify extends Vue {
   get trimmedCertifiedBy (): string {
     // remove repeated inline whitespace, and leading/trailing whitespace
     return this.certifiedBy && this.certifiedBy.replace(/\s+/g, ' ').trim()
+  }
+
+  /** Returns the title for the authorization section based on the authorization mode. */
+  get authorizationTitle (): string {
+    return this.authorizationMode === 'certify'
+      ? 'Certify'
+      : 'Confirm Authorization'
+  }
+  /** Returns the checkbox label text based on the authorization mode. */
+  get checkboxLabelText (): string {
+    return `I ${this.authorizationMode} that the information provided is correct and that I am authorized to
+      submit this filing on behalf of the ${this.entityDisplay || '[entity type]'}.`
   }
 
   /** Prompt the field validations. */

--- a/tests/unit/Certify.spec.ts
+++ b/tests/unit/Certify.spec.ts
@@ -48,7 +48,8 @@ function createComponent (
   businessEmail = '',
   completingPartyEmail = '',
   disableEdit = false,
-  showLegalName = true
+  showLegalName = true,
+  authorizationMode = 'certify'
 ): Wrapper<Certify> {
   return mount(Certify, {
     propsData: {
@@ -63,7 +64,8 @@ function createComponent (
       businessEmail,
       completingPartyEmail,
       disableEdit,
-      showLegalName
+      showLegalName,
+      authorizationMode
     },
     vuetify
   })
@@ -248,17 +250,35 @@ describe('Certify - authorization statement', () => {
 
   it('displays the Confirm Authorization label', () => {
     const wrapper: Wrapper<Certify> =
-      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false)
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false,
+        'confirm')
 
     expect(wrapper.text()).toContain('Confirm Authorization')
   })
 
-  it('displays the authorization statement instead of the certify statement', () => {
+  it('displays the Certify label', () => {
     const wrapper: Wrapper<Certify> =
-      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false)
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false,
+        'certify')
+
+    expect(wrapper.text()).toContain('Certify')
+  })
+
+  it('displays the authorization statement in authorization mode instead of the certify statement', () => {
+    const wrapper: Wrapper<Certify> =
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false, 'confirm')
     const statement: Wrapper<Vue> = wrapper.find(statementSelector)
 
     expect(statement.text()).toContain('I confirm that the information provided is correct')
+    expect(statement.text()).not.toContain('certify that I have relevant knowledge')
+  })
+
+  it('displays the authorization statement not in authorization mode instead of the certify statement', () => {
+    const wrapper: Wrapper<Certify> =
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false, 'certify')
+    const statement: Wrapper<Vue> = wrapper.find(statementSelector)
+
+    expect(statement.text()).toContain('I certify that the information provided is correct')
     expect(statement.text()).not.toContain('certify that I have relevant knowledge')
   })
 

--- a/tests/unit/Certify.spec.ts
+++ b/tests/unit/Certify.spec.ts
@@ -266,7 +266,8 @@ describe('Certify - authorization statement', () => {
 
   it('displays the authorization statement in authorization mode instead of the certify statement', () => {
     const wrapper: Wrapper<Certify> =
-      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false, 'confirm')
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false,
+        'confirm')
     const statement: Wrapper<Vue> = wrapper.find(statementSelector)
 
     expect(statement.text()).toContain('I confirm that the information provided is correct')
@@ -275,7 +276,8 @@ describe('Certify - authorization statement', () => {
 
   it('displays the authorization statement not in authorization mode instead of the certify statement', () => {
     const wrapper: Wrapper<Certify> =
-      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false, 'certify')
+      createComponent(undefined, undefined, undefined, defaultDate, false, false, [], false, '', '', false, false,
+        'certify')
     const statement: Wrapper<Vue> = wrapper.find(statementSelector)
 
     expect(statement.text()).toContain('I certify that the information provided is correct')


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31843 

*Description of changes:*
- Add `authorizationMode` prop ('certify' | 'confirm')
- Display different label/text based on `authorizationMode`
- Add/update unit tests

Example with "certify":
<img width="588" height="215" alt="image" src="https://github.com/user-attachments/assets/ed448bc7-79a7-4d70-8049-943ee5f8baae" />

Example with "confirm":
<img width="622" height="214" alt="image" src="https://github.com/user-attachments/assets/ad764eb5-757f-468a-8b8c-1f7abf34417e" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
