### PR TITLE
Certify - remove smaller font size styling

### DIFF
--- a/src/components/certify/Certify.vue
+++ b/src/components/certify/Certify.vue
@@ -285,12 +285,10 @@ export default class Certify extends Vue {
   margin: 0;
   padding-top: 1rem;
   color: $gray7;
-  font-size: 0.875rem;
 }
 
 .certify-stmt {
   display: inline;
-  font-size: 0.875rem;
   color: $gray7;
   font-weight: normal;
 }


### PR DESCRIPTION
*Issue #:* /bcgov/entity#31842 bcgov/entity#32805

*Description of changes:*
- requested by scott to keep font size the same default as the rest of the page

storybook example:

<img width="1543" height="177" alt="Screenshot 2026-05-05 at 1 10 24 PM" src="https://github.com/user-attachments/assets/0c2ab4b0-7b1d-40b8-b888-c08d51ce6307" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
