### PR TITLE
chore(release): publish

### DIFF
--- a/src/components/base-address/package-lock.json
+++ b/src/components/base-address/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcrs-shared-components/base-address",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcrs-shared-components/base-address",
-      "version": "2.0.56",
+      "version": "2.2.6",
       "dependencies": {
         "vuelidate": "0.6.2"
       }

--- a/src/components/base-address/package.json
+++ b/src/components/base-address/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bcrs-shared-components/base-address",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "publishConfig": {
     "access": "public"
   },

--- a/src/components/certify/package-lock.json
+++ b/src/components/certify/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@bcrs-shared-components/certify",
-      "version": "2.2.2",
+      "version": "2.2.4",
       "dependencies": {
         "@bcrs-shared-components/interfaces": "^1.1.41",
         "dompurify": "^3.4.1",

--- a/src/components/completing-party/package-lock.json
+++ b/src/components/completing-party/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bcrs-shared-components/completing-party",
-  "version": "2.1.101",
+  "version": "2.1.102",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@bcrs-shared-components/completing-party",
-      "version": "2.1.83",
+      "version": "2.1.102",
       "dependencies": {
         "vuelidate": "0.6.2"
       }

--- a/src/components/completing-party/package.json
+++ b/src/components/completing-party/package.json
@@ -1,11 +1,11 @@
 {
   "name": "@bcrs-shared-components/completing-party",
-  "version": "2.1.101",
+  "version": "2.1.102",
   "publishConfig": {
     "access": "public"
   },
   "dependencies": {
-    "@bcrs-shared-components/base-address": "^2.2.5",
+    "@bcrs-shared-components/base-address": "^2.2.6",
     "@bcrs-shared-components/interfaces": "^1.1.41",
     "lodash": "4.17.21",
     "vue": "^2.7.14",


### PR DESCRIPTION
 - @bcrs-shared-components/base-address@2.2.6
 - @bcrs-shared-components/completing-party@2.1.102

*Issue #:* /bcgov/entity#33209

*Description of changes:*
- chore published base address and completing party (it pulls in base address as a dep)
- update to certify is inconsequential - just got picked up doing the lerna version update

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of the business-filings-ui license (Apache 2.0).
